### PR TITLE
fixup syntax

### DIFF
--- a/app/components/GetChar.js
+++ b/app/components/GetChar.js
@@ -11,14 +11,10 @@ function Button (props) {
   )
 }
 
-function GenerateRealmOptions (props) {
-  return (
-    {
-      props.realmList.map(function(realm) {
-        return <option value={realm.slug}>{realm.name}</option>;
-      })
-    }
-  )
+function generateRealmOptions (props) {
+  return props.realmList.map(function(realm) {
+    return <option value={realm.slug}>{realm.name}</option>;
+  });
 }
 
 
@@ -29,7 +25,7 @@ function RealmField (props) {
       onChange={props.onUpdateRealm}
       value={props.charRealm}>
         <option value="" disabled>Realm</option>
-        <GenerateRealmOptions />
+        {generateRealmOptions(props)}
     </select>
   )
 }
@@ -50,6 +46,7 @@ function GetChar (props) {
     <form className="form-inline">
       <RealmField
         onUpdateRealm={props.onUpdateRealm}
+        realmList={props.realmList}
         charRealm={props.charRealm} />
       <NameField
         onUpdateName={props.onUpdateName}

--- a/app/containers/GetCharContainer.js
+++ b/app/containers/GetCharContainer.js
@@ -24,7 +24,7 @@ var GetCharContainer = React.createClass({
   },
   createRealmList: function (realmData) {
     console.log(realmData);
-    that.setState({
+    this.setState({
       realmList: realmData
     });
   },


### PR DESCRIPTION
Fixed a few things
 - changed `that` to `this` since you're using built in react binding
 - fixed not passing props down all the way
 - made generateRealmOptions not a component, since components have to be a single element at the top level, and it's returning an array of option elements. 